### PR TITLE
Criada configuração para transição de issues para discussões

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,17 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Dicas
+    url: https://github.com/backend-br/forum/discussions/new?category=dicas
+    about: Compartilhe uma dica com a comunidade!
+
+  - name: Discussão
+    url: https://github.com/backend-br/forum/discussions/new?category=discussao
+    about: Proponha discussões ou reflexões sobre assuntos relacionados ao mundo backend!
+
+  - name: Mostre seu trabalho
+    url: https://github.com/backend-br/forum/discussions/new?category=mostre-seu-trabalho
+    about: Compartilhe o que tem criado e desenvolvido!
+
+  - name: Perguntas e Respostas
+    url: https://github.com/backend-br/forum/discussions/new?category=perguntas-e-respostas
+    about: Faça perguntas para a comunidade!

--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
-# forum
+<img src="https://avatars3.githubusercontent.com/u/30732658?v=4&s=200.jpg" alt="logo-backend-br">
+
+# Fórum
+
 :beer: :coffee: Dúvidas, sugestões ou questões em gerais sobre BackEnd
+
+# Código de Conduta
+
+Leia nosso [codigo de conduta](CODE_OF_CONDUCT) para entender o propósito do repositório, regras e punições.
+
+# Licença
+
+[MIT](LICENSE) &copy; BackEndBR
+
+# Repositórios do Back-End Brasil
+
+- [Vagas](https://github.com/backend-br/vagas)
+- [Eventos](https://github.com/backend-br/eventos)
+- [Colabore](https://github.com/backend-br/desafios)
+- [Poste mais!](https://github.com/backend-br/poste-mais)
+- [Desafios](https://github.com/backend-br/desafios)


### PR DESCRIPTION
Olá amigos, assim como comentei na issue #104, criei os arquivos de configuração para transição das issues para a nova funcionalidade de discussões aqui do github.

Essa configuração impede que criem novas issues e encaminha o pessoal para a pagina de discussões com a categoria já setada.

Dei uma atualizada no readme também para ficar no mesmo padrão que os outros repositórios da organização.

Observação: utilizei as categorias que acredito que fazem sentido, algumas precisam ser criadas e configuradas lá na aba de discussões.

Vlw!